### PR TITLE
refactor Tags

### DIFF
--- a/src/Tags.zig
+++ b/src/Tags.zig
@@ -44,10 +44,16 @@ pub fn findTags(self: *Tags, fname: []const u8) anyerror!void {
         var file = try std.fs.cwd().openFile(fname, .{});
         defer file.close();
 
-        const size = try file.getEndPos();
+        const metadata = try file.metadata();
+        const size = metadata.size();
         if (size == 0) {
             return;
         }
+
+        if (metadata.kind() == .Directory) {
+            return error.NotFile;
+        }
+
         break :a try std.os.mmap(null, size, std.os.PROT.READ, std.os.MAP.SHARED, file.handle, 0);
     };
     defer std.os.munmap(mapped);

--- a/src/main.zig
+++ b/src/main.zig
@@ -33,7 +33,16 @@ pub fn main() anyerror!u8 {
             fname
         else
             try std.fs.cwd().realpathAlloc(allocator, fname);
-        try tags.findTags(full_fname);
+        tags.findTags(full_fname) catch |err| switch (err) {
+            error.NotFile => {
+                try std.io.getStdErr().writer().print(
+                    "Error: {s} is a directory. Arguments must be Zig source files.\n",
+                    .{full_fname},
+                );
+                return 22; // EINVAL
+            },
+            else => return err,
+        };
     }
 
     try tags.write(options.output);


### PR DESCRIPTION
ref: https://github.com/gpanders/ztags/pull/3

It's more reasonable to pass `allocator` to `init`.

Remove GitHub related changes.